### PR TITLE
[feat] change title dynamically

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useEscape } from "../../hooks";
+import { useEscape, useTitle } from "../../hooks";
 import { addTask } from "./utils/add-task";
 import { HiddenLabel } from "./HiddenLabel";
 import { useTask } from "../../context/task-context";
@@ -25,6 +25,7 @@ export function Modal({
   const { tasks, setTasks } = useTask();
 
   useEscape(setShow);
+  useTitle("Add task | Clockwork");
 
   const handleModalChange = (e) => {
     const { id: key, value } = e.target;

--- a/src/components/home/home.jsx
+++ b/src/components/home/home.jsx
@@ -1,7 +1,10 @@
 import { Link } from "react-router-dom";
 import HomeSvg from "../../assets/HomeSvg.svg";
+import { useTitle } from "../../hooks";
 
 export function Home() {
+  useTitle("Home | Clockwork");
+
   return (
     <main className="home-main p-1 mt-2">
       <figure>

--- a/src/components/pomoclock/pomoclock.jsx
+++ b/src/components/pomoclock/pomoclock.jsx
@@ -3,6 +3,7 @@ import { CircularProgressbar } from "react-circular-progressbar";
 import "react-circular-progressbar/dist/styles.css";
 import { useEffect, useRef, useState } from "react";
 import { FaPlay, FaPause, FaStop } from "react-icons/fa";
+import { useTitle } from "../../hooks";
 
 export function Pomoclock() {
   const location = useLocation();
@@ -86,6 +87,7 @@ export function Pomoclock() {
 
   const percentValue = (seconds / totalSeconds) * 100;
 
+  useTitle(`${minutesLeft}:${secondsLeft} 🎯 | Clockwork`);
   return (
     <main className="pomoclock-main ">
       <section className="pomoclock">

--- a/src/components/task/task.jsx
+++ b/src/components/task/task.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { FaPlusCircle } from "react-icons/fa";
 import { useTask } from "../../context/task-context";
+import { useTitle } from "../../hooks";
 
 import { Modal } from "../Modal/Modal";
 import { ReactPortal } from "../ReactPortal.js";
@@ -16,6 +17,7 @@ export function Task() {
   useEffect(() => {
     setTasks(getTasks());
   }, []);
+  useTitle("Task | Clockwork");
 
   return (
     <main className="task-main p-1">

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,1 +1,2 @@
 export { useEscape } from "./useEscape";
+export { useTitle } from "./useTitle";

--- a/src/hooks/useTitle.js
+++ b/src/hooks/useTitle.js
@@ -1,0 +1,7 @@
+import { useEffect } from "react";
+
+export function useTitle(title) {
+  useEffect(() => {
+    document.title = title;
+  });
+}


### PR DESCRIPTION
The title of the app now changes per route. 

Also, minutes and seconds are visible when the user is on pomoclock page.